### PR TITLE
Fix name discrepancy in `LICENSE`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -25,7 +25,7 @@ No warranties are given. The license may not give you all of the permissions nec
 # Software
 
 Except where otherwise noted, the example programs and other software
-provided in the project-avalon repository are made available under the
+provided in the DSCI-532_2024_16_SilentEpidemic repository are made available under the
 MIT license.
 
 **MIT License**


### PR DESCRIPTION
This PR fixes the incorrect name being used in the `LICENSE` file.