### PR TITLE
Add footer at bottom of the sidebar

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@ from dash import Dash, html, dcc
 import dash_bootstrap_components as dbc
 import plotly.express as px
 import pandas as pd
+from modules.components import footer
 
 app = Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
 
@@ -53,20 +54,17 @@ sidebar = html.Div(
         html.Div(children=[
             # TODO: Toggle button
         ]),
+        footer
     ],
     style=SIDEBAR_STYLE,
 )
 
 
 main_dashboard = html.Div(children=[
-    html.Div(children='Overdose deaths'),
-
-    dcc.Graph(
-        id='example-graph',
-        figure=fig),
-],
-    id="page-content",
-    style=CONTENT_STYLE)
+        html.Div(children='Overdose deaths'),
+        dcc.Graph(id='example-graph', figure=fig),
+    ],
+    id="page-content", style=CONTENT_STYLE)
 
 
 app.layout = html.Div(children=[

--- a/src/modules/components/__init__.py
+++ b/src/modules/components/__init__.py
@@ -1,0 +1,1 @@
+from .footer import footer

--- a/src/modules/components/footer.py
+++ b/src/modules/components/footer.py
@@ -1,0 +1,13 @@
+from dash import html, dcc
+from ..utils import REPO_URL, get_repo_last_updated_time
+
+
+footer = html.Footer(children=[
+    html.Div("This is dashboard for visualizing the trend in deaths caused by drug overdoses in the United States from 1999 to 2021."),
+    html.Br(),
+    html.Div("Authors: Orix Au Yeung (@SoloSynth1), Yingzi Jin (@jinyz8888), Alysen Townsley (@AlysenTownsley), Bill Wan (@billwan96)"),
+    html.Br(),
+    dcc.Link(children="Link to repo", href=REPO_URL, target="_blank"),
+    html.Br(),
+    html.Div("Last Updated: " + get_repo_last_updated_time().strftime("%B %d, %Y")),
+])

--- a/src/modules/utils.py
+++ b/src/modules/utils.py
@@ -1,0 +1,11 @@
+import requests
+from datetime import datetime
+
+REPO_NAME = "UBC-MDS/DSCI-532_2024_16_SilentEpidemic"
+REPO_URL = f"https://github.com/{REPO_NAME}"
+API_ENDPOINT = f"https://api.github.com/repos/{REPO_NAME}"
+
+
+def get_repo_last_updated_time():
+    repo_info = requests.get(API_ENDPOINT).json()
+    return datetime.fromisoformat(repo_info['pushed_at'])


### PR DESCRIPTION
This PR adds a foot at the bottom of the sidebar.

The sidebar include the following items:
- Short description of the dashboard
- Name and GitHub handle of the authors
- A URL link to the GitHub Repo
- An self-updating last updated date

Closes #52.