### PR TITLE
Fix `gunicorn` failing to start WSGI server on render.com

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,7 @@ from dash import Dash, html, dcc
 import dash_bootstrap_components as dbc
 import plotly.express as px
 import pandas as pd
-from modules.components import footer
+from .modules.components import footer
 
 app = Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server

--- a/src/app.py
+++ b/src/app.py
@@ -4,6 +4,7 @@ import plotly.express as px
 import pandas as pd
 
 app = Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
+server = app.server
 
 # test data, to be removed
 df = pd.DataFrame({


### PR DESCRIPTION
This PR addresses the deployment pipeline failing on render.com caused by the lack of WSGI server.

Changes:
- expose WSGI server (`app.server`) for gunicorn to call
- add `src/__init__.py`
- use relative import for in-module imports

Closes #40.