### PR TITLE
feat: Change colour palettes used

### DIFF
--- a/src/modules/components/deaths.py
+++ b/src/modules/components/deaths.py
@@ -56,7 +56,10 @@ def update_main_figure(selected_drug, selected_sex, selected_years, selected_age
     filtered_df = main_df.groupby(['Drug Type', 'Year', 'Population Type']).agg({'Deaths': 'sum', 'Death Rate': 'mean'}).reset_index()
     filtered_df = filtered_df.fillna(0)
 
-    fig_deaths_and_rates = px.scatter(filtered_df, x='Year', y='Deaths', color='Drug Type', size='Death Rate', size_max=60)
+    fig_deaths_and_rates = px.scatter(
+        filtered_df, x='Year',y='Deaths', color='Drug Type',
+        size='Death Rate', size_max=60, color_discrete_sequence=px.colors.qualitative.Prism
+    )
 
     # Update layout
     fig_deaths_and_rates.update_layout(xaxis_title='Year', yaxis_title='Deaths',

--- a/src/modules/components/demo.py
+++ b/src/modules/components/demo.py
@@ -26,7 +26,9 @@ def update_demo_figure(selected_drug, selected_years):
     filtered_df = demo_df[(demo_df['Drug Type'].isin(selected_drug)) &
                           (demo_df['Year'] >= selected_years[0]) &
                           (demo_df['Year'] <= selected_years[1])]
-    fig_demo = px.bar(filtered_df, x="Year", y="Death Rate", color="Demographic", barmode="group")
+    fig_demo = px.bar(
+        filtered_df, x="Year", y="Death Rate", color="Demographic",
+        barmode="group", color_discrete_sequence=px.colors.qualitative.T10)
 
     fig_demo.update_layout(
         xaxis_title="Year",

--- a/src/modules/components/opioid.py
+++ b/src/modules/components/opioid.py
@@ -69,13 +69,19 @@ def update_opioid_figure(selected_drug, selected_sex, selected_years, selected_a
         'Percent Opioid Deaths'].sum().reset_index()
 
     # Create scatter plot with trendlines for males
-    fig_percent_opioid_deaths = px.line(filtered_opioid_df[filtered_opioid_df['Sex'] == 'Male'], x='Year', y='Percent Opioid Deaths', color='Drug Type')
+    fig_percent_opioid_deaths = px.line(
+        filtered_opioid_df[filtered_opioid_df['Sex'] == 'Male'], x='Year',
+        y='Percent Opioid Deaths', color='Drug Type', color_discrete_sequence=px.colors.qualitative.T10
+    )
     for trace in fig_percent_opioid_deaths.data:
         trace.line.dash = 'dash'
         trace.name += ' (Male)' 
 
     # Add scatter points for females to the existing plot
-    for trace in px.line(filtered_opioid_df[filtered_opioid_df['Sex'] == 'Female'], x='Year', y='Percent Opioid Deaths', color='Drug Type').data:
+    for trace in px.line(
+            filtered_opioid_df[filtered_opioid_df['Sex'] == 'Female'], x='Year',
+            y='Percent Opioid Deaths', color='Drug Type', color_discrete_sequence=px.colors.qualitative.T10
+    ).data:
         trace.name += ' (Female)' 
         fig_percent_opioid_deaths.add_trace(trace)
 


### PR DESCRIPTION
This PR aims to address the issue that all our charts are using the default colour palette which is too cheerful and not appropriate given the grave nature of the overdose problem.

Changes:
- make bubble chart to use `px.colors.qualitative.Prism`
- make opioid and demo chart to use `px.colors.qualitative.T10`

Here is the dashboard after replacing the colour palette:
<img width="2560" alt="image" src="https://github.com/UBC-MDS/DSCI-532_2024_16_SilentEpidemic/assets/17952490/7965ee89-8d96-4d5c-a060-6085eb0f7a5d">

Closes #91.