### PR TITLE
Enhance subtitle to provide death rate information

### DIFF
--- a/src/modules/components/deaths.py
+++ b/src/modules/components/deaths.py
@@ -60,7 +60,19 @@ def update_main_figure(selected_drug, selected_sex, selected_years, selected_age
 
     # Update layout
     fig_deaths_and_rates.update_layout(xaxis_title='Year', yaxis_title='Deaths',
-                                       legend=dict(orientation="h",yanchor="bottom", y=1.02))
+                                       legend=dict(orientation="h", yanchor="bottom", y=1.02))
+
+    # Add hints indicating bubble size as death rate
+    # This is added since plotly currently does not support displaying a legend for marker size
+    # Possible workaround exists but requires creating another trace which is not ideal for the styling
+    #
+    # Refer to:
+    # https://github.com/plotly/plotly.py/issues/3505
+    # https://github.com/plotly/plotly.js/issues/5099
+    # https://stackoverflow.com/questions/66190742/plotly-scatter-bubble-plot-marker-size-in-legend?noredirect=1&lq=1
+    # https://stackoverflow.com/questions/66686072/size-legend-for-plotly-express-scatterplot-in-python
+
+    title = title + ", Death Rate Proportional to Size of Bubbles"
 
     return fig_deaths_and_rates.to_dict(), title
 

--- a/src/modules/components/demo.py
+++ b/src/modules/components/demo.py
@@ -17,11 +17,9 @@ fig_demo = go.Figure()
      Input('year_range_slider', 'value')]
 )
 def update_demo_figure(selected_drug, selected_years):
-    if len(selected_drug) == 9:
-        selected_drug = ['Total Overdose Deaths']
+    if len(selected_drug) == 8:
         title = "All Drugs"
     else:
-        selected_drug = selected_drug
         title = f"For {' and '.join(selected_drug)}"
     filtered_df = demo_df[(demo_df['Drug Type'].isin(selected_drug)) &
                           (demo_df['Year'] >= selected_years[0]) &


### PR DESCRIPTION
This PR enhances the subtitle of the main plot to provide death rate information.

Adding a legend for marker size is not supported by plotly currently. Please refer to the comment in #92.

This RP also fixes the fix broken control statement in demo graph's callback function, which still checking if the number of `selected_drug` is 9 (i.e. including the option "All opioid".)

Closes #92.