### PR TITLE
feat: Add placeholder for charts when charts do not have data to render under current filter selection

### DIFF
--- a/src/modules/components/deaths.py
+++ b/src/modules/components/deaths.py
@@ -5,7 +5,7 @@ import plotly.express as px
 
 from ..datasets import main_df
 from ..constants import UNIQUE_DRUG_TYPES, COLOR_SEQUENCE
-from ..utils import get_px_figure_with_default_template
+from ..utils import get_px_figure_with_default_template, get_placeholder_figure
 
 
 fig_deaths_and_rates = get_px_figure_with_default_template()
@@ -20,10 +20,12 @@ fig_deaths_and_rates = get_px_figure_with_default_template()
      Input('age_group_radio', 'value')]
 )
 def update_main_figure(selected_drug, selected_sex, selected_years, selected_age):
-    if not selected_drug or not selected_sex:
-        return get_px_figure_with_default_template(), "Please select at least one drug type and one sex category"
-
     start_year, end_year = [pd.to_datetime(x, format='%Y') for x in selected_years]
+
+    if not selected_drug:
+        return get_placeholder_figure("Please select at least one drug type"), ""
+    elif not selected_sex:
+        return get_placeholder_figure("Please select at least one sex category"), ""
 
     # Words to display in the subtitle
     age_display = "All Age Groups" if selected_age == 'Overall' else selected_age

--- a/src/modules/components/demo.py
+++ b/src/modules/components/demo.py
@@ -4,7 +4,7 @@ import dash_bootstrap_components as dbc
 
 from ..datasets import demo_df
 from ..constants import UNIQUE_DEMOS, DEMO_COLOR_SEQUENCE
-from ..utils import get_px_figure_with_default_template
+from ..utils import get_px_figure_with_default_template, get_placeholder_figure
 
 # create graph for the demographic
 fig_demo = get_px_figure_with_default_template()
@@ -19,6 +19,12 @@ fig_demo = get_px_figure_with_default_template()
 ])
 def update_demo_figure(selected_drug, selected_years):
     start_year, end_year = selected_years
+
+    if not selected_drug:
+        return get_placeholder_figure("Please select at least one drug type"), ""
+    elif start_year == end_year:
+        return get_placeholder_figure("Please select a year range that spans more than one year."), ""
+
     filtered_df = demo_df[(demo_df['Year'].between(start_year, end_year))]
     if len(selected_drug) == 8:
         title = "All Drugs"

--- a/src/modules/components/sidebar.py
+++ b/src/modules/components/sidebar.py
@@ -28,7 +28,7 @@ sidebar = dbc.Container([
                        'Stimulants', 'Cocaine', 'Psychostimulants', 'Benzodiazepines', 'Antidepressants'],
                 placeholder = "Select a drug type",
                 multi=True,
-                clearable=False)
+                clearable=True)
                        
         ]),
         dbc.Row([html.Hr()]),

--- a/src/modules/utils.py
+++ b/src/modules/utils.py
@@ -13,3 +13,15 @@ def get_repo_last_updated_time():
 
 def get_px_figure_with_default_template():
     return go.Figure(layout=dict(template='plotly'))
+
+
+def get_placeholder_figure(message="Nothing to show.", fontsize=16):
+    fig = get_px_figure_with_default_template()
+    fig.add_annotation(
+        x=5,
+        y=5,
+        text=message,
+        font={'family': "system-ui", 'size': fontsize},
+        showarrow=False
+    ).update_yaxes(range=[0, 10]).update_xaxes(range=[0, 10])
+    return fig


### PR DESCRIPTION
This PR adds a special chart for showing errors when selected filters are incorrect.

Also re-enables the `clearable` argument in the multiselect dropdown menu.

Closes #149.