### PR TITLE
fix: Replace empty demo chart with placeholder chart

### DIFF
--- a/src/modules/components/demo.py
+++ b/src/modules/components/demo.py
@@ -4,7 +4,7 @@ import dash_bootstrap_components as dbc
 
 from .tooltip import create_tooltip
 from ..datasets import demo_df
-from ..constants import UNIQUE_DEMOS, DEMO_COLOR_SEQUENCE
+from ..constants import UNIQUE_DEMOS, DEMO_COLOR_SEQUENCE, DRUG_NO_DEMO_DATA_AVAILABLE
 from ..utils import get_px_figure_with_default_template, get_placeholder_figure
 
 # create graph for the demographic
@@ -24,7 +24,9 @@ def update_demo_figure(selected_drug, selected_years):
     if not selected_drug:
         return get_placeholder_figure("Please select at least one drug type"), ""
     elif start_year == end_year:
-        return get_placeholder_figure("Please select a year range that spans more than one year."), ""
+        return get_placeholder_figure("Please select a year range that spans more than one year"), ""
+    elif not (set(selected_drug) - DRUG_NO_DEMO_DATA_AVAILABLE):
+        return get_placeholder_figure("No data is available for selected drugs"), ""
 
     filtered_df = demo_df[(demo_df['Year'].between(start_year, end_year))]
     if len(selected_drug) == 8:

--- a/src/modules/components/opioid.py
+++ b/src/modules/components/opioid.py
@@ -30,7 +30,7 @@ def update_opioid_figure(selected_drug, selected_sex, selected_years, selected_a
     elif not selected_sex:
         return get_placeholder_figure("Please select at least one sex category"), ""
     elif start_year == end_year:
-        return get_placeholder_figure("Please select a year range that spans more than one year."), ""
+        return get_placeholder_figure("Please select a year range that spans more than one year"), ""
 
 
     filtered_opioid_df = opioid_df.dropna(subset=['Percent Opioid Deaths'])

--- a/src/modules/constants.py
+++ b/src/modules/constants.py
@@ -2,6 +2,7 @@ import plotly.express as px
 
 DRUG_OPIOIDS = {'Prescription opioids', 'Synthetic opioids', 'Heroin'}
 DRUG_NON_OPIOIDS = {'Stimulants', 'Cocaine', 'Psychostimulants', 'Benzodiazepines', 'Antidepressants'}
+DRUG_NO_DEMO_DATA_AVAILABLE = {'Antidepressants', 'Benzodiazepines'}
 UNIQUE_DRUG_TYPES = ('Antidepressants', 'Benzodiazepines', 'Cocaine', 'Heroin', 'Prescription opioids', 'Psychostimulants', 'Stimulants', 'Synthetic opioids')
 UNIQUE_DEMOS = ('Overall', 'American Indian or Alaska Native (Non-Hispanic)', 'Asian (Non-Hispanic)', 'Black (Non-Hispanic)', 'Hispanic', 'Native Hawaiin or Other Pacific Islander (Non-Hispanic)', 'White (Non-Hispanic)')
 


### PR DESCRIPTION
 Fix where empty demo chart would be shown when only antidepressants and/or benzodiazepine are selected.